### PR TITLE
fix: The repo can not run start

### DIFF
--- a/.umirc.js
+++ b/.umirc.js
@@ -2,7 +2,7 @@ import { join } from 'path';
 
 export default {
   plugins: [
-    require.resolve(join(__dirname, './packages/umi-plugin-sula/lib')),
+    require.resolve(join(__dirname, './packages/umi-plugin-sula/src')),
   ],
   history: {
     type: 'hash',


### PR DESCRIPTION
Fixed the following problem:

When I execute the following command:
> $ cnpm i
> $ cnpm run bootstrap
> $ cnpm start

Output:
Cannot find module '/Users/faruxue/p/sula/packages/umi-plugin-sula/lib'