### PR TITLE
bugfix: LinkProps 移除 type 属性

### DIFF
--- a/packages/sula/src/render-plugin/link/Link.tsx
+++ b/packages/sula/src/render-plugin/link/Link.tsx
@@ -3,7 +3,7 @@ import { Button } from 'antd';
 import { ButtonProps } from 'antd/lib/button';
 import assign from 'lodash/assign';
 
-export interface LinkProps extends ButtonProps{
+export interface LinkProps extends Omit<ButtonProps, 'type'>{
 }
 
 export default class Link extends React.Component<LinkProps> {


### PR DESCRIPTION
解决 Link 组件不接受 type 属性但是类型定义仍然有 type