### PR TITLE
fix: add main for package.json to resolve eslint error

### DIFF
--- a/packages/sula/package.json
+++ b/packages/sula/package.json
@@ -2,6 +2,7 @@
   "name": "sula",
   "version": "1.0.0-alpha.38",
   "module": "./es/index.js",
+  "main": "./es/index.js",
   "types": "typings/index.d.ts",
   "description": "sula",
   "peerDependencies": {


### PR DESCRIPTION
### 背景
和 https://github.com/umijs/sula/issues/48 的问题类似，当使用 js 引用 sula 的时候，eslint 会报错（代码运行没问题）：

```
  2:26  error  Unable to resolve path to module 'sula'  import/no-unresolved

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
```
### 方案
在 package.json 中添加 main 字段，指向 index.js，本地自测 eslint 不再报错。
